### PR TITLE
fix submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 
+# Generated
 *.json
-generated/
+*.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "generated"]
-	path = generated
-	url = git@github.com:orsinium/generated-awesomeness.git


### PR DESCRIPTION
It's better to add * .md files to .gitignore, and remove the submodules.

In .gitignore added folder (generated), which is a sambodule, so if you clone the project, the submodules will not update (git submodule init & git submodule update).